### PR TITLE
Fix: get last statistics row from tsv

### DIFF
--- a/lib/ya/api/direct/url_helper.rb
+++ b/lib/ya/api/direct/url_helper.rb
@@ -89,7 +89,7 @@ module Ya::API::Direct
     def self.from_tsv_to_json(response_body)
       report_name = response_body.slice!(/^(.+?)\n/)
       keys = response_body.slice!(/^(.+?)\n/).split("\t")
-      rows = response_body.match(/rows:(.+?)\n/)[1].to_i - 1
+      rows = response_body.match(/rows:(.+?)\n/)[1].to_i
       values = []
       rows.times do |row|
         hash_values = {}


### PR DESCRIPTION

он берет кол-во строк из row и зачем-то отнимает 1
 сейчас на яднексе это число равно кол-ву строк статистики

> Последняя строка отчета содержит количество строк со статистикой. 
> https://yandex.ru/dev/direct/doc/reports/report-format-docpage/

![image](https://user-images.githubusercontent.com/26512193/64321103-ed20ae80-cfd0-11e9-92ed-24942f0b1648.png)
https://yandex.ru/dev/direct/doc/reports/example-docpage/